### PR TITLE
convert app to a shell command

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "description": "Asynchronously find usernames across social networks",
   "main": "poirot.js",
+  "preferGlobal": true,
+  "bin": "poirot.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/poirot.js
+++ b/poirot.js
@@ -1,9 +1,11 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const https = require('https');
 const yargs = require('yargs');
 const chalk = require('chalk');
 
-const suspects = JSON.parse(fs.readFileSync('./data.json', 'utf-8'));
+const suspects = JSON.parse(fs.readFileSync(`${__dirname}/data.json`, 'utf-8'));
 
 const argv = yargs.argv;
 const username = process.argv[2];
@@ -55,7 +57,6 @@ function retrieve(url, suspect, suspects) {
       }
     })
     .on('error', e => {
-      //   console.error(e);
       console.log(
         chalk.bold(
           chalk.whiteBright('[') +


### PR DESCRIPTION
Make this app an executable, i.e users don't have to run `node poirot.js <username>` anymore and from within the repository, but can run `poirot <username>` from anywhere in their filesystem.

This will immediately work if already packaged on npmjs.com and users install it from there, but if not, then first run `npm link` to create the symbolic link and it will work as above.

Sorry, I guess I should have opened an issue first and see if you wanted this in your project. If you don't then that's okay as well. 😄 